### PR TITLE
Fix #10: 회원가입 api 변경으로 인한 loginType 및 code를 store에 저장하도록 변경

### DIFF
--- a/src/pages/Login/hook.ts
+++ b/src/pages/Login/hook.ts
@@ -5,7 +5,7 @@ import { useJoinInfoStore } from '../../stores/clientState/joinStore'
 export type LoginTokenType = 'kakao'
 
 export const useDoLogin = () => {
-	const { setNickname, setIsInitialNicknameDuplicate } = useJoinInfoStore()
+	const { setJoinType, setCode, setNickname, setIsInitialNicknameDuplicate } = useJoinInfoStore()
 	const { routeTo } = useRouter()
 
 	const doLogin = async (loginType: LoginTokenType, code: string) => {
@@ -22,8 +22,11 @@ export const useDoLogin = () => {
 			routeTo('/')
 		}
 
+		setJoinType(loginType)
+		setCode(code)
 		setNickname(loginRes.nickname)
 		setIsInitialNicknameDuplicate(loginRes.nicknameDuplicate)
+
 		routeTo('/join')
 	}
 

--- a/src/stores/clientState/joinStore.ts
+++ b/src/stores/clientState/joinStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { CategoryType, selectedInfoType } from '../../interfaces'
 import { defaultCategories } from '../../utilities/utils/category'
+import { LoginTokenType } from '../../types/auth'
 
 interface IJoinContentStore {
 	content: 'additionalInfo' | 'survey'
@@ -15,6 +16,10 @@ export const useJoinContentStore = create<IJoinContentStore>()(
 )
 
 interface IJoinInfoStore {
+	joinType: LoginTokenType
+	setJoinType: (joinType: LoginTokenType) => void
+	code: string
+	setCode: (code: string) => void
 	nickname: string
 	setNickname: (nickname: string) => void
 	isInitialNicknameDuplicate: boolean
@@ -28,6 +33,12 @@ interface IJoinInfoStore {
 
 export const useJoinInfoStore = create<IJoinInfoStore>()(
 	devtools((set) => ({
+		// joinType info
+		joinType: 'kakao',
+		setJoinType: (joinType: LoginTokenType) => set(() => ({ joinType })),
+		code: '',
+		setCode: (code: string) => set(() => ({ code })),
+
 		// About Additional Info
 		nickname: '',
 		setNickname: (nickname: string) => set(() => ({ nickname })),


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18WHxfIYoQEFVNixNfypGiTeTJgYJZDokU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=nPydiBk)